### PR TITLE
Xlib: Fallback to first display if app:main_display() doesn't match any

### DIFF
--- a/nw_xlib.lua
+++ b/nw_xlib.lua
@@ -992,6 +992,9 @@ function app:main_display()
 			return d
 		end
 	end
+
+	-- if none matched, return the first display available
+	return self:displays()[1]
 end
 
 function app:active_display()


### PR DESCRIPTION
I have a dual monitor setup and in my case the reported x/y are: (0,42) and (1920,0). This was causing main_display() to not return any values. With this change, we make sure to always return a value even if no displays are found at (0,0)
